### PR TITLE
[qml-rpm-macros] Fix qmldeps.sh getting confused on comments in qmldir file. JB#57391

### DIFF
--- a/qmldeps.sh
+++ b/qmldeps.sh
@@ -25,8 +25,8 @@ case $1 in
         while read file; do
             case "$file" in
                 */qmldir)
-                    if head -1 "$file" | grep -iq '^module\s*' 2>/dev/null; then
-                        provides="`head -1 ${file} | sed -r 's/^module\s+//'`"
+                    if grep -iq '^module\s*' "$file" 2>/dev/null; then
+                        provides="`grep -i '^module\s*' $file | sed -r 's/^module\s+//' | head -1`"
                         version="`grep -i -E -o '^[a-z]*[[:space:]]+[0-9.]*[[:space:]]+[a-z0-9]*.qml' ${file} \
                             | awk '{print $2}' | sort -r | uniq | head -1`"
                         if [ -z "$version" ]; then

--- a/rpm/qml-rpm-macros.spec
+++ b/rpm/qml-rpm-macros.spec
@@ -1,8 +1,7 @@
 Name: qml-rpm-macros
-Version: 0.0.1
+Version: 0.1.1
 Release: 1
 Summary: Macros for handling QML
-Group: System/Libraries
 License: GPLv2
 Source0: %{name}-%{version}.tar.gz
 BuildArch:  noarch
@@ -15,13 +14,10 @@ BuildArch:  noarch
 %{_rpmconfigdir}/fileattrs/qml.attr
 %{_rpmconfigdir}/qmldeps.sh
 
-
 %prep
 %setup -q
 
-
 %build
-
 
 %install
 install -m644 -D qml.attr %{buildroot}/%{_rpmconfigdir}/fileattrs/qml.attr


### PR DESCRIPTION
Some generated qmldir files can have an initial comment like "# This file was automatically generated by ECMQmlModule and should not be modified"

The script got confused as it was expecting the module declaration on the first line.